### PR TITLE
Add version uppser bound because some method signature is changed.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,14 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.4.3</version>
+      <version>[2.6.0,2.6.4]</version>
+      <!--
+      This version of jackson-lombok is compatible only >= 2.6.0.
+      Additional bad news: 2.7.x has API change (exception type?). Test is failed. (I don't know only test is faied now)
+      Now, jackson-lombok compiled with 2.6.4 will compatible with [2.6.0,2.6.4]
+
+      TODO: Update test for jackson 2.7.x
+      -->
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
This is fix hint of https://github.com/xebia/jackson-lombok/issues/1.

From 2.5 of jackson-databind, return type (in other words method signature) of `addOrOverride` is changed.
https://github.com/FasterXML/jackson-databind/commit/3ec253707dcfba4055e99d6af97d0d3877d0999a#diff-4f2f19b7140280e7d47b48e1d0df1139R54

So, if this module is compiled with jackson 2.4.x, it can not be used in combination with jackson 2.5.x and above.
